### PR TITLE
Fix pub.dev publish tag trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v*'
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- fix the GitHub Actions tag filter for pub.dev publishing
- use a valid tag glob so release tags like v4.26.3 actually trigger the workflow

## Testing
- not run locally
