### PR TITLE
Trim trailing empty line from README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,13 @@ format:
 fix: init
 	dart fix --apply
 
+.PHONY: format-doc
+format-doc:
+	# Trim trailing empty line
+	sed -i -e '$${/^$$/d;}' README.md
+
 .PHONY: after-gen
-after-gen: fix insert-example
+after-gen: fix insert-example format-doc
 	./scripts/annotate-deprecated.bash
 	@dart format .
 


### PR DESCRIPTION
## Summary
- Add `format-doc` target to trim trailing empty line from README.md after generation

## Test plan
- [ ] Verify `make after-gen` runs successfully
- [ ] Verify README.md has no trailing empty line after generation